### PR TITLE
adds a goproxy resolver

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,4 +17,5 @@ jobs:
       - name: Test
         run: go test ./...
         env:
+          GOPROXY: "https://proxy.golang.org"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/gobinaries.go
+++ b/gobinaries.go
@@ -3,22 +3,14 @@ package gobinaries
 
 import (
 	"context"
-	"errors"
 	"io"
+
+	"github.com/tj/gobinaries/resolver"
 )
-
-// ErrObjectNotFound is returned by Storage.Get() when no object is found for the specified key.
-var ErrObjectNotFound = errors.New("no cloud storage object")
-
-// ErrNoVersionMatch is returned by Resolver.Resolve() when no tag matches the requested version.
-var ErrNoVersionMatch = errors.New("no matching version")
-
-// ErrNoVersions is returned by Resolver.Resolve() when no versions are defined.
-var ErrNoVersions = errors.New("no versions defined")
 
 // Resolver is the interface used to resolver package versions.
 type Resolver interface {
-	Resolve(owner, repo, version string) (string, error)
+	Resolve(repo resolver.Repository) (string, error)
 }
 
 // Storage is the interface used for storing compiled Go binaries.

--- a/resolver/github.go
+++ b/resolver/github.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/google/go-github/v28/github"
 
-	"github.com/tj/gobinaries"
 	"github.com/tj/gobinaries/semver"
 )
 
@@ -19,9 +18,9 @@ type GitHub struct {
 }
 
 // Resolve implementation.
-func (g *GitHub) Resolve(owner, repo, version string) (string, error) {
+func (g *GitHub) Resolve(repo Repository) (string, error) {
 	// fetch tags
-	tags, err := g.versions(owner, repo)
+	tags, err := g.versions(repo.Owner, repo.Project)
 	if err != nil {
 		return "", err
 	}
@@ -35,12 +34,12 @@ func (g *GitHub) Resolve(owner, repo, version string) (string, error) {
 	}
 
 	// master special-case
-	if version == "master" {
+	if repo.Version == "master" {
 		return versions[0].String(), nil
 	}
 
 	// match requested semver range
-	vr, err := semver.ParseRange(version)
+	vr, err := semver.ParseRange(repo.Version)
 	if err != nil {
 		return "", fmt.Errorf("parsing version range: %w", err)
 	}
@@ -51,7 +50,7 @@ func (g *GitHub) Resolve(owner, repo, version string) (string, error) {
 		}
 	}
 
-	return "", gobinaries.ErrNoVersionMatch
+	return "", ErrNoVersionMatch
 }
 
 // versions returns the versions of a repository.
@@ -84,7 +83,7 @@ func (g *GitHub) versions(owner, repo string) (versions []string, err error) {
 	}
 
 	if len(versions) == 0 {
-		return nil, gobinaries.ErrNoVersions
+		return nil, ErrNoVersions
 	}
 
 	return

--- a/resolver/goproxy.go
+++ b/resolver/goproxy.go
@@ -1,0 +1,58 @@
+package resolver
+
+import (
+	"bufio"
+	"fmt"
+	"net/http"
+	"sort"
+
+	"github.com/tj/gobinaries/semver"
+)
+
+// modListURLTemplate is the well known location for getting a go modules
+// version list from a GOPROXY.
+const modListURLTemplate = "%s/%s/%s/%s/@v/list"
+
+// GoProxy holds the location of the GOPROXY a user wants to resolve
+// versions with.
+type GoProxy struct {
+	URL string
+}
+
+// Resolve attempts to resolve a properly formatted repository / verison
+// via the GOPROXY (acting like the request is a module).
+func (g *GoProxy) Resolve(repo Repository) (string, error) {
+	repoURL := fmt.Sprintf(modListURLTemplate, g.URL, repo.Location, repo.Owner, repo.Project)
+
+	resp, err := http.Get(repoURL)
+	if err != nil {
+		return "", fmt.Errorf("goproxy failed to get verions: %w", err)
+	}
+	defer resp.Body.Close()
+
+	scanner := bufio.NewScanner(resp.Body)
+
+	var versions []semver.Version
+	for scanner.Scan() {
+		token := string(scanner.Bytes())
+		if v, err := semver.Parse(token); err == nil {
+			versions = append(versions, v)
+		}
+	}
+
+	// sort ascending for all versions
+	sort.Sort(sort.Reverse(semver.Versions(versions)))
+
+	vr, err := semver.ParseRange(repo.Version)
+	if err != nil {
+		return "", fmt.Errorf("parsing version range: %w", err)
+	}
+
+	for _, v := range versions {
+		if vr.Match(v) {
+			return v.String(), nil
+		}
+	}
+
+	return "", ErrNoVersionMatch
+}

--- a/resolver/goproxy_test.go
+++ b/resolver/goproxy_test.go
@@ -1,42 +1,31 @@
 package resolver_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/google/go-github/v28/github"
 	"github.com/tj/assert"
 	"github.com/tj/go/env"
-	"golang.org/x/oauth2"
-
 	"github.com/tj/gobinaries"
 	"github.com/tj/gobinaries/resolver"
 )
 
-// newGitHubResolver returns a new GitHub resolver.
-func newGitHubResolver() gobinaries.Resolver {
-	ctx := context.Background()
-
-	ts := oauth2.StaticTokenSource(
-		&oauth2.Token{
-			AccessToken: env.Get("GITHUB_TOKEN"),
-		},
-	)
-
-	return &resolver.GitHub{
-		Client: github.NewClient(oauth2.NewClient(ctx, ts)),
+// newGoProxyResolver returns a new GitHub resolver.
+func newGoProxyResolver() gobinaries.Resolver {
+	return &resolver.GoProxy{
+		URL: env.Get("GOPROXY"),
 	}
 }
 
 // Test resolver.
-func TestGitHub_Resolve(t *testing.T) {
-	r := newGitHubResolver()
+func TestGoProxy_Resolve(t *testing.T) {
+	r := newGoProxyResolver()
 
 	t.Run("exact match", func(t *testing.T) {
 		repo := resolver.Repository{
-			Owner:   "tj",
-			Project: "d3-bar",
-			Version: "v1.8.0",
+			Location: "github.com",
+			Owner:    "tj",
+			Project:  "d3-bar",
+			Version:  "v1.8.0",
 		}
 		v, err := r.Resolve(repo)
 		assert.NoError(t, err)
@@ -45,9 +34,10 @@ func TestGitHub_Resolve(t *testing.T) {
 
 	t.Run("exact match without leading v", func(t *testing.T) {
 		repo := resolver.Repository{
-			Owner:   "tj",
-			Project: "d3-bar",
-			Version: "1.8.0",
+			Location: "github.com",
+			Owner:    "tj",
+			Project:  "d3-bar",
+			Version:  "1.8.0",
 		}
 		v, err := r.Resolve(repo)
 		assert.NoError(t, err)
@@ -56,9 +46,10 @@ func TestGitHub_Resolve(t *testing.T) {
 
 	t.Run("major wildcard match", func(t *testing.T) {
 		repo := resolver.Repository{
-			Owner:   "tj",
-			Project: "d3-bar",
-			Version: "1.x",
+			Location: "github.com",
+			Owner:    "tj",
+			Project:  "d3-bar",
+			Version:  "1.x",
 		}
 		v, err := r.Resolve(repo)
 		assert.NoError(t, err)
@@ -67,9 +58,10 @@ func TestGitHub_Resolve(t *testing.T) {
 
 	t.Run("minor wildcard match", func(t *testing.T) {
 		repo := resolver.Repository{
-			Owner:   "tj",
-			Project: "d3-bar",
-			Version: "1.6.x",
+			Location: "github.com",
+			Owner:    "tj",
+			Project:  "d3-bar",
+			Version:  "1.6.x",
 		}
 		v, err := r.Resolve(repo)
 		assert.NoError(t, err)
@@ -78,23 +70,13 @@ func TestGitHub_Resolve(t *testing.T) {
 
 	t.Run("minor match", func(t *testing.T) {
 		repo := resolver.Repository{
-			Owner:   "tj",
-			Project: "d3-bar",
-			Version: "1.6",
+			Location: "github.com",
+			Owner:    "tj",
+			Project:  "d3-bar",
+			Version:  "1.6",
 		}
 		v, err := r.Resolve(repo)
 		assert.NoError(t, err)
 		assert.Equal(t, "v1.6.0", v)
-	})
-
-	t.Run("master", func(t *testing.T) {
-		repo := resolver.Repository{
-			Owner:   "tj",
-			Project: "d3-bar",
-			Version: "master",
-		}
-		v, err := r.Resolve(repo)
-		assert.NoError(t, err)
-		assert.Equal(t, "v1.8.0", v)
 	})
 }

--- a/resolver/types.go
+++ b/resolver/types.go
@@ -1,0 +1,21 @@
+package resolver
+
+import "errors"
+
+// ErrNoVersionMatch is returned by Resolver.Resolve() when no tag matches the requested version.
+var ErrNoVersionMatch = errors.New("no matching version")
+
+// ErrNoVersions is returned by Resolver.Resolve() when no versions are defined.
+var ErrNoVersions = errors.New("no versions defined")
+
+// Respository holds the details of where,
+// who, and what version of a repository we
+// are trying to resolve. Location is not used
+// by GitHub as we KNOW the location is always
+// GitHub.
+type Repository struct {
+	Location string
+	Owner    string
+	Project  string
+	Version  string
+}

--- a/storage/google.go
+++ b/storage/google.go
@@ -54,7 +54,7 @@ func (g *Google) Get(ctx context.Context, bin gobinaries.Binary) (io.ReadCloser,
 	r, err := obj.NewReader(ctx)
 
 	if isNotExists(err) {
-		return nil, gobinaries.ErrObjectNotFound
+		return nil, ErrObjectNotFound
 	}
 
 	return r, nil

--- a/storage/google_test.go
+++ b/storage/google_test.go
@@ -75,7 +75,7 @@ func TestGoogle_Get(t *testing.T) {
 		}
 
 		_, err := s.Get(ctx, bin)
-		assert.Equal(t, gobinaries.ErrObjectNotFound, err)
+		assert.Equal(t, storage.ErrObjectNotFound, err)
 	})
 }
 


### PR DESCRIPTION
Currently we've hardcoded the proxy, this is just a wip for now and will
be configurable from the root.

This is just a resolver for now to make sure that the code style,
errors, and the small refactors look good here.

The future direction of this would to be to attempt to use
the goproxy resolver and then failing that, fall back to
GitHub (but open to suggestions here).

Please open an issue and discuss changes before spending time on them, unless the change is trivial or an issue already exists.
