### PR TITLE
Add support for +v2 modules

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/tj/gobinaries"
@@ -71,7 +72,7 @@ func Write(w io.Writer, bin gobinaries.Binary) error {
 	}
 
 	// add the dependency
-	err = addModuleDep(dir, bin.Module+"@"+bin.Version)
+	err = addModuleDep(dir, normalizeModuleDep(bin))
 	if err != nil {
 		return fmt.Errorf("adding dependency: %w", err)
 	}
@@ -141,6 +142,28 @@ func addModule(dir string) error {
 	cmd.Env = append(cmd.Env, "GO111MODULE=on")
 	cmd.Dir = dir
 	return command(cmd)
+}
+
+// getMajorVersion tries to detect the major version of the package.
+func getMajorVersion(tag string) (int, error) {
+	major := strings.Split(tag, ".")[0]
+	if len(major) < 1 {
+		return 0, fmt.Errorf("invalid major version")
+	}
+	return strconv.Atoi(major[1:])
+}
+
+func normalizeModuleDep(bin gobinaries.Binary) string {
+	mod := bin.Module
+	version := bin.Version
+	var dep string
+	major, err := getMajorVersion(version)
+	if err == nil && major > 1 {
+		dep = fmt.Sprintf("%s/v%d@%s", mod, major, version)
+	} else {
+		dep = fmt.Sprintf("%s@%s", mod, version)
+	}
+	return dep
 }
 
 // addModuleDep creates a module dependency.

--- a/server/util.go
+++ b/server/util.go
@@ -1,8 +1,19 @@
 package server
 
 import (
+	"fmt"
+	"strconv"
 	"strings"
 )
+
+// getMajorVersion tries to detect the major version of the package.
+func getMajorVersion(tag string) (int, error) {
+	major := strings.Split(tag, ".")[0]
+	if len(major) < 1 {
+		return 0, fmt.Errorf("invalid major version")
+	}
+	return strconv.Atoi(major[1:])
+}
 
 // parsePackage returns package information parsed from the path.
 func parsePackage(path string) (pkg, mod, version, bin string) {


### PR DESCRIPTION
This adds support to Go packages that have versions above v2. Similar to `go get` the `/v2` major version has to be declared when making the package build request:

Usage: 

```sh
# Explicit +v2 version
curl -sf 'http://localhost:3000/nats-io/nats-server@v2.1.6' | PREFIX=. sh

# Resolved version gets v2 from master
curl -sf 'http://localhost:3000/nats-io/nats-server' | PREFIX=. sh

# Explicit v1 version
curl -sf 'http://localhost:3000/nats-io/nats-server@v1.4.1' | PREFIX=. sh

# v2 nested modules too 🎉 
curl -sf 'http://localhost:3000/caddyserver/caddy/cmd/caddy' | PREFIX=. sh
```

If the major version is not specified in the path, similar to go get and go modules, it will fallback to the v1 version of the package (even if the actual latest version is higher).

```sh
curl --output - 'http://127.0.0.1:3000/binary/github.com/nats-io/nats-server?os=darwin&arch=amd64&version=v2.1.6' > my-nats-v1
./my-nats-v1 
[98946] 2020/05/07 16:54:40.726190 [INF] Starting nats-server version 1.4.1
```

Fixes #10 

Signed-off-by: Waldemar Quevedo <wally@synadia.com>

