### PR TITLE
Setting CGO_ENABLED=0

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -181,6 +181,7 @@ func buildBinary(dir, dst string, bin gobinaries.Binary) error {
 	ldflags := fmt.Sprintf("-X main.version=%s", bin.Version)
 	cmd := exec.Command("go", "build", "-o", dst, "-ldflags", ldflags, bin.Path)
 	cmd.Env = environ()
+	cmd.Env = append(cmd.Env, "CGO_ENABLED=0")
 	cmd.Env = append(cmd.Env, "GO111MODULE=on")
 	cmd.Env = append(cmd.Env, "GOOS="+bin.OS)
 	cmd.Env = append(cmd.Env, "GOARCH="+bin.Arch)


### PR DESCRIPTION
This makes the binaries fully static also on Linux/amd64 so they work on Alpine too. Should fix #4 

To address the biggest concern: yes, this makes it impossible to build binaries that have dependencies on native code (CGo). This should not really be an issue, however: gobinaries is designed for cross-compilation, which means CGo wasn't usable before anyways. In fact, `CGO_ENABLED` is already disabled when cross-compiling; this PR disables it for Linux/amd64 too.