### PR TITLE
bump to golang 1.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15
+FROM golang:1.16
 WORKDIR /app
 COPY go.* ./
 RUN go mod download


### PR DESCRIPTION
closes #36
closes https://github.com/datacharmer/dbdeployer/issues/132

Just copying off d62cc321d3781fd3f04babc98e37f4fb009ec249

Please open an issue and discuss changes before spending time on them, unless the change is trivial or an issue already exists.
