### PR TITLE
Support Windows through powershell

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -172,7 +172,10 @@ func (s *Server) getScript(w http.ResponseWriter, r *http.Request) {
 		Version:         resolved,
 	}
 	useragent := r.Header.Get("User-Agent")
-	if strings.Contains(strings.ToUpper(useragent), strings.ToUpper("POWERSHELL")) {
+	ispowershell := strings.Contains(strings.ToUpper(useragent), strings.ToUpper("POWERSHELL"))
+	iswindows := strings.Contains(strings.ToUpper(useragent), strings.ToUpper("WINDOWS"))
+
+	if ispowershell && iswindows {
 		s.render(w, "install.ps1", templateData)
 	} else {
 		s.render(w, "install.sh", templateData)

--- a/server/server.go
+++ b/server/server.go
@@ -158,7 +158,7 @@ func (s *Server) getScript(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	s.render(w, "install.sh", struct {
+	templateData := struct {
 		URL             string
 		Package         string
 		Binary          string
@@ -170,7 +170,13 @@ func (s *Server) getScript(w http.ResponseWriter, r *http.Request) {
 		Binary:          bin,
 		OriginalVersion: version,
 		Version:         resolved,
-	})
+	}
+	useragent := r.Header.Get("User-Agent")
+	if strings.Contains(strings.ToUpper(useragent), strings.ToUpper("POWERSHELL")) {
+		s.render(w, "install.ps1", templateData)
+	} else {
+		s.render(w, "install.sh", templateData)
+	}
 }
 
 // getBinary builds and responds with the requested package binary,

--- a/templates/install.ps1
+++ b/templates/install.ps1
@@ -1,0 +1,80 @@
+#!/usr/bin/env pwsh
+
+function Log-Info($message) {
+	Write-Output "`e[38;5;61m  ==>`e[0;00m $message"
+}
+function Log-Critical($message) {
+	[Console]::Error.WriteLine("")
+	[Console]::Error.WriteLine("  `e[38;5;125m$message`e[0;00m")
+	[Console]::Error.WriteLine("")
+}
+function Get-OS() {
+	if ($IsWindows) {
+		return "windows"
+	} else {
+		Log-Critical("Operating system not supported yet")
+		Exit 0
+	}
+	return "unknown"
+}
+function Get-Architecture() {
+	return "$env:PROCESSOR_ARCHITECTURE".ToLower()
+}
+
+$OS = Get-OS
+$Arch = Get-Architecture
+
+# API endpoint such as "http://localhost:3000"
+$API="{{.URL}}"
+
+# package such as "github.com/tj/triage/cmd/triage"
+$Pkg="{{.Package}}"
+
+# binary name such as "hello"
+$Bin="{{.Binary}}"
+
+# original_version such as "master"
+$OriginalVersion="{{.OriginalVersion}}"
+
+# version such as "master"
+$Version="{{.Version}}"
+
+$GoBinariesDir = $env:GOBINARIES_DIR
+$BinDir = If ($GoBinariesDir) {
+  "$GoBinariesDir\bin"
+} else {
+  "$HOME\.gobinaries\bin"
+}
+
+$TempExe = "$env:TEMP\$Bin.exe"
+$TargetExe = "$BinDir\$Bin.exe"	
+
+If ($OriginalVersion -ne $Version) {
+	Log-Info("Resolved version $OriginalVersion to $Version")
+}
+
+# GitHub requires TLS 1.2
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+Log-Info("Downloading binary for $OS $arch")
+$DownloadUrl = "${API}/binary/${Pkg}?os=${OS}&arch=${Arch}&version=${Version}"
+Invoke-WebRequest $DownloadUrl -OutFile $TempExe -UseBasicParsing
+
+If (!(Test-Path $BinDir)) {
+  New-Item $BinDir -ItemType Directory | Out-Null
+}
+
+Copy-Item -Path $TempExe -Destination $TargetExe
+
+If (Test-Path $TempExe) {
+	Remove-Item $TempExe
+}
+
+$User = [EnvironmentVariableTarget]::User
+$Path = [Environment]::GetEnvironmentVariable('Path', $User)
+If (!(";$Path;".ToLower() -like "*;$BinDir;*".ToLower())) {
+  [Environment]::SetEnvironmentVariable('Path', "$Path;$BinDir", $User)
+  $Env:Path += ";$BinDir"
+}
+
+Log-Info("Installation complete")


### PR DESCRIPTION
I created a powershell version of the script that works reasonably well.
I think this could be released as some kind of alpha.

Basically two changes:
1. Add an `install.ps1` template file
2. Create a conditional at the endpoint that generates the script that detects if the _user agent_ is a powershell and if so, renders the renderization of the `install.ps1` template.

Closes #2 